### PR TITLE
Added viewport for mobile compatibility

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -10,6 +10,7 @@
 
 {%- block extrahead %}
 {{ super() }}
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 <script type="text/javascript">
 
   var _gaq = _gaq || [];


### PR DESCRIPTION
This doesn't make the page appear much different, but at least Google won't push it down for missing the viewport html tag now. We should continue to make the page more mobile-friendly, however.